### PR TITLE
fix(starter #4): it be s.survivalTimeout.

### DIFF
--- a/dubbo-go-boot-starter/starter.go
+++ b/dubbo-go-boot-starter/starter.go
@@ -74,7 +74,7 @@ func (s *Starter) Start() (err error) {
 	if err != nil {
 		return err
 	}
-	component.ObserveSignal(DefaultSurvivalTimeout, func() {
+	component.ObserveSignal(s.survivalTimeout, func() {
 		middleware.Shutdown()
 	})
 	return nil


### PR DESCRIPTION
fix(starter #4): it be s.survivalTimeout.

https://github.com/dubbogo/dubbo-go-boot/blob/aef900ef7c1bfb5c35a419aacf65299b57d4d3cc/dubbo-go-boot-starter/starter.go#L77